### PR TITLE
Refactor: initialize time zone data eagerly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 1.0.1
+  - Refactor: initialize time zone data eagerly [#2](https://github.com/logstash-plugins/logstash-mixin-scheduler/pull/2)
+
 ## 1.0.0
   - Feat: a common scheduler interface [#1](https://github.com/logstash-plugins/logstash-mixin-scheduler/pull/1)

--- a/lib/logstash/plugin_mixins/scheduler/rufus_impl.rb
+++ b/lib/logstash/plugin_mixins/scheduler/rufus_impl.rb
@@ -1,5 +1,11 @@
 require 'rufus/scheduler'
-
+begin
+  require 'et-orbi.rb' # a dependency of rufus-scheduler since 3.4
+  ::EtOrbi::EoTime.now # might take a long time to initialize - loading time zone
+  # data (from tz-info) and thus gets un-predictable on CI, since the scheduler worker
+  # thread might be stuck starting while we attempt to shutdown in a given time frame
+rescue LoadError
+end
 require 'logstash/util/loggable'
 
 module LogStash module PluginMixins module Scheduler module RufusImpl

--- a/logstash-mixin-scheduler.gemspec
+++ b/logstash-mixin-scheduler.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-scheduler'
-  s.version       = '1.0.0'
+  s.version       = '1.0.1'
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Scheduler for Logstash plugins"
   s.authors       = %w(Elastic)


### PR DESCRIPTION
Normally, with up-to-date rufus-scheduler, `EoTime.now` happens on `Scheduler.new ...` (from [`start`](https://github.com/jmettraux/rufus-scheduler/blob/v3.8.1/lib/rufus/scheduler.rb#L627=)).

The problem is the mixin lazily initializes the scheduler on first use and thus the actual start of the scheduler might take a considerable time (esp. on CI) - this is problematic in terms of testing behavior that is using the scheduler (and has been a cause of several :red_circle: false positives in plugins). 

The code itself is [extracted from http_poller](https://github.com/logstash-plugins/logstash-input-http_poller/pull/130/files#diff-1d7bf70c65d6e2eb17422ea0b0631355257caaf7334a3e71dbdc92aa43204e56R12) and the change immediately stabilized the CI build, since we do not want to have scheduler impl specific code all over the plugin I am moving the eager initialization into the mixin.

---

This is not a concern for currently used rufus 3.0 (which simply uses `Time.now`), thus the `LoadError` rescue. Once LS core updates the scheduler to `>= 3.4` we could remove the rescue.